### PR TITLE
BUPH-70 | fixes for the demo

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4fa73e65b40b0294979da366f1cb67a",
+    "content-hash": "58ddf9484f3d931993867c9cddd4e4ce",
     "packages": [
         {
             "name": "psr/cache",

--- a/src/Actor/Template/Tokenizer.php
+++ b/src/Actor/Template/Tokenizer.php
@@ -123,12 +123,6 @@ class Tokenizer implements TokenizerInterface
             );
             /** @noinspection CascadeStringReplacementInspection */
             $tokenizedContents = str_replace(
-                sprintf('\%s\\', $this->getActorTemplate()->getFabricationFileActor()->getTemplateFileName()),
-                sprintf('%s\\', TokenizerInterface::EMPTY_TOKEN),
-                $tokenizedContents
-            );
-            /** @noinspection CascadeStringReplacementInspection */
-            $tokenizedContents = str_replace(
                 '\Actor',
                 sprintf('\%s', TokenizerInterface::RELATIVE_CLASS_PATH_TOKEN),
                 $tokenizedContents

--- a/src/AnnotationProcessor/ContextInterface.php
+++ b/src/AnnotationProcessor/ContextInterface.php
@@ -9,6 +9,8 @@ interface ContextInterface
 {
     public function setFabricationFile(FabricationFileInterface $FabricationFile);
 
+    public function getFabricationFile(): FabricationFileInterface;
+
     public function getStaticContextRecord(): array;
 
     public function setStaticContextRecord(array $static_context_record): ContextInterface;


### PR DESCRIPTION
- Removing the Actor name was creating conflicts with referencing similar actors
  _e.g._ referencing `Actor\Builder` in `Actor\Map\Builder`
  - Tested against the Test file and none of those actors changed, but the Buphalo templates don't include `Map\Builder` files.

- Added `getFabricationFile` to `ContextInterface` since it was public on the model

(Composer lock update is just a link change, so figure it should happen at some point)