### PR TITLE
BUPH-116 | Initial fix of duplicate Annotations

### DIFF
--- a/src/V1/Actor/Template/AnnotationTokenizer.php
+++ b/src/V1/Actor/Template/AnnotationTokenizer.php
@@ -17,6 +17,8 @@ class AnnotationTokenizer implements AnnotationTokenizerInterface
 
     protected $TokenizedContents;
 
+    private $memoizedAnnotationProcessors = [];
+
     public function tokenize(): AnnotationTokenizerInterface
     {
         $this->getTokenizedContents();
@@ -60,10 +62,15 @@ class AnnotationTokenizer implements AnnotationTokenizerInterface
         $targetActor = $this->getActorTemplate()->getFabricationFileActor();
         $annotationProcessor = null;
         if ($targetActor->hasAnnotationProcessorMap()) {
-            $annotationProcessors = $targetActor->getAnnotationProcessorMap();
             $annotationProcessorIndex = trim($annotations[2][$index]);
+            if (isset($this->memoizedAnnotationProcessors[$annotationProcessorIndex])) {
+                return $this->memoizedAnnotationProcessors[$annotationProcessorIndex];
+            }
+
+            $annotationProcessors = $targetActor->getAnnotationProcessorMap();
             if (isset($annotationProcessors[$annotationProcessorIndex])) {
                 $annotationProcessor = $annotationProcessors[$annotationProcessorIndex];
+                $this->memoizedAnnotationProcessors[$annotationProcessorIndex] = $annotationProcessor;
             }
         }
         // "default" processor - trim out the annotation.


### PR DESCRIPTION
This does NOT allow for the duplicate tag to have different annotation contents

This assumes that all occurrences of the annotation key in the annotation can be replaced by subsequent calls of a single Annotation Processor's `getReplacement()` method.

This breaks if:
- Someone wrote their `getReplacement()` method to not be idempotent. (If calling it multiple times breaks or produces unintended results)
- If a user wants a different set of default text (annotation contents) in each tag, because the annotation contents will only be set once, and the first one will override the any subsequent ones.

Because these cases are subsets of the existing issues (they will also fail in all of the existing cases where this current solution does not), we can address those cases with a more advanced solution at a later time.