### PR TITLE
HOTFIX | sync V1 changes to V2 objects

### DIFF
--- a/src/V2/AnnotationProcessors/SimpleString.php
+++ b/src/V2/AnnotationProcessors/SimpleString.php
@@ -12,11 +12,13 @@ class SimpleString implements V2\AnnotationProcessorInterface
         getAnnotationProcessorContext as public;
     }
 
+    public const CONTEXT_KEY_STRING = 'string';
+
     public function getReplacement(): string
     {
         $staticContextRecord = $this->getAnnotationProcessorContext()->getStaticContextRecord();
 
-        return $staticContextRecord['string'];
+        return $staticContextRecord[self::CONTEXT_KEY_STRING];
     }
 
 

--- a/src/V2/AnnotationProcessors/SymfonyExpression.php
+++ b/src/V2/AnnotationProcessors/SymfonyExpression.php
@@ -13,6 +13,8 @@ class SymfonyExpression implements V2\AnnotationProcessorInterface
         getAnnotationProcessorContext as public;
     }
 
+    public const CONTEXT_KEY_EXPRESSION = 'expression';
+
     public function getReplacement(): string
     {
         $context = $this->getAnnotationProcessorContext()->getStaticContextRecord();
@@ -20,7 +22,7 @@ class SymfonyExpression implements V2\AnnotationProcessorInterface
 
         $expressionLanguage = new ExpressionLanguage();
         return (string) $expressionLanguage->evaluate(
-            $context['expression'],
+            $context[self::CONTEXT_KEY_EXPRESSION],
             [
                 'context' => $this->getAnnotationProcessorContext()
             ]

--- a/src/V2/Api/Dumper.php
+++ b/src/V2/Api/Dumper.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\Buphalo\V2\Api;
+
+use Neighborhoods\Buphalo;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Yaml;
+
+class Dumper implements DumperInterface
+{
+    /** @var Filesystem */
+    private $filesystem;
+
+    /** @var string */
+    private $basePath;
+
+    public function __construct(?string $basePath = null)
+    {
+        if ($basePath) {
+            $this->setBasePath($basePath);
+        }
+    }
+
+    public function dumpFile(FabricationFileInterface $fabricationFile): Dumper
+    {
+        $this->getFilesystem()->dumpFile($this->buildFilePath($fabricationFile), $this->dump($fabricationFile));
+
+        return $this;
+    }
+
+    private function buildFilePath(FabricationFileInterface $fabricationFile): string
+    {
+        return sprintf(
+            implode(DIRECTORY_SEPARATOR, ['%s', '%s', '%s']) . '.%s',
+            $this->getBasePath(),
+            $fabricationFile->getRelativePath(),
+            $fabricationFile->getPrimaryActorName(),
+            Buphalo\V2\FabricationFileInterface::FILE_EXTENSION_FABRICATION
+        );
+    }
+
+    public function dump(FabricationFileInterface $fabricationFile): string
+    {
+        $data = \json_decode(\json_encode($fabricationFile), true);
+
+        // Not strictly necessary for ephemeral files, but these keys would be ignored by Buphalo anyway
+        unset(
+            $data[FabricationFileInterface::PROP_RELATIVE_PATH],
+            $data[FabricationFileInterface::PROP_PRIMARY_ACTOR_NAME]
+        );
+
+        return Yaml\Yaml::dump($data, PHP_INT_MAX, 2);
+    }
+
+    private function getFilesystem(): Filesystem
+    {
+        if ($this->filesystem === null) {
+            $this->filesystem = new Filesystem();
+        }
+
+        return $this->filesystem;
+    }
+
+    public function setBasePath(string $basePath): void
+    {
+        $this->basePath = $basePath;
+    }
+
+    private function getBasePath(): string
+    {
+        if ($this->basePath === null) {
+            throw new \LogicException('Dumper basePath has not been set.');
+        }
+
+        return $this->basePath;
+    }
+}

--- a/src/V2/Api/DumperInterface.php
+++ b/src/V2/Api/DumperInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\Buphalo\V2\Api;
+
+interface DumperInterface
+{
+    public function dumpFile(FabricationFileInterface $fabricationFile): Dumper;
+
+    public function dump(FabricationFileInterface $fabricationFile): string;
+}

--- a/src/V2/Api/FabricationFile.php
+++ b/src/V2/Api/FabricationFile.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\Buphalo\V2\Api;
+
+use Neighborhoods\Buphalo\V2\StringMapInterface;
+
+class FabricationFile implements FabricationFileInterface
+{
+    /** @var StringMapInterface */
+    private $preferred_template_trees;
+
+    /** @var FabricationFile\Actor\MapInterface */
+    private $actors;
+
+    /** @var string */
+    private $relative_path;
+
+    /** @var string */
+    private $primary_actor_name;
+
+    public function getPreferredTemplateTrees(): StringMapInterface
+    {
+        if ($this->preferred_template_trees === null) {
+            throw new \LogicException('preferred_template_trees has not been set');
+        }
+
+        return $this->preferred_template_trees;
+    }
+
+    public function setPreferredTemplateTrees(StringMapInterface $preferred_template_trees): FabricationFileInterface
+    {
+        if ($this->preferred_template_trees !== null) {
+            throw new \LogicException('preferred_template_trees has already been set');
+        }
+
+        $this->preferred_template_trees = $preferred_template_trees;
+        return $this;
+    }
+
+    public function hasPreferredTemplateTrees(): bool
+    {
+        return $this->preferred_template_trees !== null;
+    }
+
+
+    public function getActors(): FabricationFile\Actor\MapInterface
+    {
+        if ($this->actors === null) {
+            throw new \LogicException('actors has not been set');
+        }
+
+        return $this->actors;
+    }
+
+    public function setActors(FabricationFile\Actor\MapInterface $actors): FabricationFileInterface
+    {
+        if ($this->actors !== null) {
+            throw new \LogicException('actors has already been set');
+        }
+
+        $this->actors = $actors;
+        return $this;
+    }
+
+    public function getRelativePath(): string
+    {
+        if ($this->relative_path === null) {
+            throw new \LogicException('FabricationFile relativePath has not been set.');
+        }
+
+        return $this->relative_path;
+    }
+
+    public function setRelativePath(string $relative_path): FabricationFileInterface
+    {
+        $this->relative_path = $relative_path;
+
+        return $this;
+    }
+
+    public function getPrimaryActorName(): string
+    {
+        if ($this->primary_actor_name === null) {
+            throw new \LogicException('FabricationFile primaryActorName has not been set.');
+        }
+
+        return $this->primary_actor_name;
+    }
+
+    public function setPrimaryActorName(string $primary_actor_name): FabricationFileInterface
+    {
+        $this->primary_actor_name = $primary_actor_name;
+
+        return $this;
+    }
+
+    public function jsonSerialize()
+    {
+        return get_object_vars($this);
+    }
+
+}

--- a/src/V2/Api/FabricationFile/Actor.php
+++ b/src/V2/Api/FabricationFile/Actor.php
@@ -1,0 +1,94 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Buphalo\V2\Api\FabricationFile;
+
+use Neighborhoods\Buphalo\V2\StringMapInterface;
+use Neighborhoods\Buphalo\V2\Api\FabricationFile\Actor\AnnotationProcessor;
+
+class Actor implements ActorInterface
+{
+    /** @var string */
+    private $template;
+
+    /** @var StringMapInterface */
+    private $preferred_template_trees;
+
+    /** @var AnnotationProcessor\MapInterface */
+    private $annotation_processors;
+
+     public function getTemplate(): string
+     {
+         if ($this->template === null) {
+             throw new \LogicException('template has not been set');
+         }
+         
+         return $this->template;
+     }
+     
+     public function setTemplate(string $template): ActorInterface
+     {
+         if ($this->template !== null) {
+             throw new \LogicException('template has already been set');
+         }
+         
+         $this->template = $template;
+         return $this;
+     }
+     
+
+     public function getPreferredTemplateTrees(): StringMapInterface
+     {
+         if ($this->preferred_template_trees === null) {
+             throw new \LogicException('preferred_template_trees has not been set');
+         }
+         
+         return $this->preferred_template_trees;
+     }
+     
+     public function setPreferredTemplateTrees(StringMapInterface $preferred_template_trees): ActorInterface
+     {
+         if ($this->preferred_template_trees !== null) {
+             throw new \LogicException('preferred_template_trees has already been set');
+         }
+         
+         $this->preferred_template_trees = $preferred_template_trees;
+         return $this;
+     }
+     
+     public function hasPreferredTemplateTrees(): bool
+     {
+        return $this->preferred_template_trees !== null;
+     }
+     
+
+     public function getAnnotationProcessors(): AnnotationProcessor\MapInterface
+     {
+         if ($this->annotation_processors === null) {
+             throw new \LogicException('annotation_processors has not been set');
+         }
+         
+         return $this->annotation_processors;
+     }
+     
+     public function setAnnotationProcessors(AnnotationProcessor\MapInterface $annotation_processors): ActorInterface
+     {
+         if ($this->annotation_processors !== null) {
+             throw new \LogicException('annotation_processors has already been set');
+         }
+         
+         $this->annotation_processors = $annotation_processors;
+         return $this;
+     }
+     
+     public function hasAnnotationProcessors(): bool
+     {
+        return $this->annotation_processors !== null;
+     }
+     
+
+    public function jsonSerialize()
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/V2/Api/FabricationFile/Actor/AnnotationProcessor.php
+++ b/src/V2/Api/FabricationFile/Actor/AnnotationProcessor.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Buphalo\V2\Api\FabricationFile\Actor;
+
+class AnnotationProcessor implements AnnotationProcessorInterface
+{
+    /** @var string */
+    private $processor_fqcn;
+
+    /** @var array */
+    private $static_context_record;
+
+     public function getProcessorFqcn(): string
+     {
+         if ($this->processor_fqcn === null) {
+             throw new \LogicException('processor_fqcn has not been set');
+         }
+         
+         return $this->processor_fqcn;
+     }
+     
+     public function setProcessorFqcn(string $processor_fqcn): AnnotationProcessorInterface
+     {
+         if ($this->processor_fqcn !== null) {
+             throw new \LogicException('processor_fqcn has already been set');
+         }
+         
+         $this->processor_fqcn = $processor_fqcn;
+         return $this;
+     }
+     
+     public function getStaticContextRecord(): array
+     {
+         if ($this->static_context_record === null) {
+             throw new \LogicException('static_context_record has not been set');
+         }
+         
+         return $this->static_context_record;
+     }
+     
+     public function setStaticContextRecord(array $static_context_record): AnnotationProcessorInterface
+     {
+         if ($this->static_context_record !== null) {
+             throw new \LogicException('static_context_record has already been set');
+         }
+         
+         $this->static_context_record = $static_context_record;
+         return $this;
+     }
+     
+     public function hasStaticContextRecord(): bool
+     {
+        return $this->static_context_record !== null;
+     }
+
+    public function jsonSerialize()
+    {
+        return get_object_vars($this);
+    }
+}

--- a/src/V2/Api/FabricationFile/Actor/AnnotationProcessor/Map.php
+++ b/src/V2/Api/FabricationFile/Actor/AnnotationProcessor/Map.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Buphalo\V2\Api\FabricationFile\Actor\AnnotationProcessor;
+
+use Neighborhoods\Buphalo\V2\Api\FabricationFile\Actor\AnnotationProcessorInterface;
+
+class Map extends \ArrayIterator implements MapInterface
+{
+    /** @param AnnotationProcessorInterface ...$AnnotationProcessors */
+    public function __construct(array $AnnotationProcessors = array(), int $flags = 0)
+    {
+        if ($this->count() !== 0) {
+            throw new \LogicException('Map is not empty.');
+        }
+
+        if (!empty($AnnotationProcessors)) {
+            $this->assertValidArrayType(...array_values($AnnotationProcessors));
+        }
+
+        parent::__construct($AnnotationProcessors, $flags);
+    }
+
+    public function offsetGet($index): AnnotationProcessorInterface
+    {
+        return $this->assertValidArrayItemType(parent::offsetGet($index));
+    }
+
+    /** @param AnnotationProcessorInterface $AnnotationProcessor */
+    public function offsetSet($index, $AnnotationProcessor)
+    {
+        parent::offsetSet($index, $this->assertValidArrayItemType($AnnotationProcessor));
+    }
+
+    /** @param AnnotationProcessorInterface $AnnotationProcessor */
+    public function append($AnnotationProcessor)
+    {
+        $this->assertValidArrayItemType($AnnotationProcessor);
+        parent::append($AnnotationProcessor);
+    }
+
+    public function current(): AnnotationProcessorInterface
+    {
+        return parent::current();
+    }
+
+    protected function assertValidArrayItemType(AnnotationProcessorInterface $AnnotationProcessor)
+    {
+        return $AnnotationProcessor;
+    }
+
+    protected function assertValidArrayType(AnnotationProcessorInterface ...$AnnotationProcessors): MapInterface
+    {
+        return $this;
+    }
+
+    public function getArrayCopy(): MapInterface
+    {
+        return new self(parent::getArrayCopy(), (int)$this->getFlags());
+    }
+
+    public function toArray(): array
+    {
+        return (array)$this;
+    }
+
+    /** @param AnnotationProcessorInterface ...$AnnotationProcessors */
+    public function hydrate(array $AnnotationProcessors): MapInterface
+    {
+        $this->__construct($AnnotationProcessors);
+
+        return $this;
+    }
+}

--- a/src/V2/Api/FabricationFile/Actor/AnnotationProcessor/MapInterface.php
+++ b/src/V2/Api/FabricationFile/Actor/AnnotationProcessor/MapInterface.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Buphalo\V2\Api\FabricationFile\Actor\AnnotationProcessor;
+
+use Neighborhoods\Buphalo\V2\Api\FabricationFile\Actor\AnnotationProcessorInterface;
+
+interface MapInterface extends \SeekableIterator, \ArrayAccess, \Serializable, \Countable
+{
+    /** @param AnnotationProcessorInterface ...$AnnotationProcessors */
+    public function __construct(array $AnnotationProcessors = array(), int $flags = 0);
+
+    public function offsetGet($index): AnnotationProcessorInterface;
+
+    /** @param AnnotationProcessorInterface $AnnotationProcessor */
+    public function offsetSet($index, $AnnotationProcessor);
+
+    /** @param AnnotationProcessorInterface $AnnotationProcessor */
+    public function append($AnnotationProcessor);
+
+    public function current(): AnnotationProcessorInterface;
+
+    public function getArrayCopy(): MapInterface;
+
+    public function toArray(): array;
+
+    /** @param AnnotationProcessorInterface ...$AnnotationProcessors */
+    public function hydrate(array $AnnotationProcessors): MapInterface;
+}

--- a/src/V2/Api/FabricationFile/Actor/AnnotationProcessorInterface.php
+++ b/src/V2/Api/FabricationFile/Actor/AnnotationProcessorInterface.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Buphalo\V2\Api\FabricationFile\Actor;
+
+interface AnnotationProcessorInterface extends \JsonSerializable
+{
+    public const PROP_PROCESSOR_FQCN = 'processor_fqcn';
+    public const PROP_STATIC_CONTEXT_RECORD = 'static_context_record';
+
+    public function getProcessorFqcn(): string;
+    public function setProcessorFqcn(string $processor_fqcn): AnnotationProcessorInterface;
+
+    public function getStaticContextRecord(): array;
+    public function setStaticContextRecord(array $static_context_record): AnnotationProcessorInterface;
+    public function hasStaticContextRecord(): bool;
+}

--- a/src/V2/Api/FabricationFile/Actor/Map.php
+++ b/src/V2/Api/FabricationFile/Actor/Map.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Buphalo\V2\Api\FabricationFile\Actor;
+
+use Neighborhoods\Buphalo\V2\Api\FabricationFile\ActorInterface;
+
+class Map extends \ArrayIterator implements MapInterface
+{
+    /** @param ActorInterface ...$Actors */
+    public function __construct(array $Actors = [], int $flags = 0)
+    {
+        if ($this->count() !== 0) {
+            throw new \LogicException('Map is not empty.');
+        }
+
+        if (!empty($Actors)) {
+            $this->assertValidArrayType(...array_values($Actors));
+        }
+
+        parent::__construct($Actors, $flags);
+    }
+
+    public function offsetGet($index): ActorInterface
+    {
+        return $this->assertValidArrayItemType(parent::offsetGet($index));
+    }
+
+    /** @param ActorInterface $Actor */
+    public function offsetSet($index, $Actor)
+    {
+        parent::offsetSet($index, $this->assertValidArrayItemType($Actor));
+    }
+
+    /** @param ActorInterface $Actor */
+    public function append($Actor)
+    {
+        $this->assertValidArrayItemType($Actor);
+        parent::append($Actor);
+    }
+
+    public function current(): ActorInterface
+    {
+        return parent::current();
+    }
+
+    protected function assertValidArrayItemType(ActorInterface $Actor)
+    {
+        return $Actor;
+    }
+
+    protected function assertValidArrayType(ActorInterface ...$Actors): MapInterface
+    {
+        return $this;
+    }
+
+    public function getArrayCopy(): MapInterface
+    {
+        return new self(parent::getArrayCopy(), (int)$this->getFlags());
+    }
+
+    public function toArray(): array
+    {
+        return (array)$this;
+    }
+
+    /** @param ActorInterface ...$Actors */
+    public function hydrate(array $Actors): MapInterface
+    {
+        $this->__construct($Actors);
+
+        return $this;
+    }
+}

--- a/src/V2/Api/FabricationFile/Actor/MapInterface.php
+++ b/src/V2/Api/FabricationFile/Actor/MapInterface.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Buphalo\V2\Api\FabricationFile\Actor;
+
+use Neighborhoods\Buphalo\V2\Api\FabricationFile\ActorInterface;
+
+interface MapInterface extends \SeekableIterator, \ArrayAccess, \Serializable, \Countable
+{
+    /** @param ActorInterface ...$Actors */
+    public function __construct(array $Actors = [], int $flags = 0);
+
+    public function offsetGet($index): ActorInterface;
+
+    /** @param ActorInterface $Actor */
+    public function offsetSet($index, $Actor);
+
+    /** @param ActorInterface $Actor */
+    public function append($Actor);
+
+    public function current(): ActorInterface;
+
+    public function getArrayCopy(): MapInterface;
+
+    public function toArray(): array;
+
+    /** @param ActorInterface ...$Actors */
+    public function hydrate(array $Actors): MapInterface;
+}

--- a/src/V2/Api/FabricationFile/ActorInterface.php
+++ b/src/V2/Api/FabricationFile/ActorInterface.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\Buphalo\V2\Api\FabricationFile;
+
+use Neighborhoods\Buphalo\V2\StringMapInterface;
+use Neighborhoods\Buphalo\V2\Api\FabricationFile\Actor\AnnotationProcessor;
+
+interface ActorInterface extends \JsonSerializable
+{
+    public const PROP_TEMPLATE = 'template';
+    public const PROP_PREFERRED_TEMPLATE_TREES = 'preferred_template_trees';
+    public const PROP_ANNOTATION_PROCESSORS = 'annotation_processors';
+
+    public function getTemplate(): string;
+    public function setTemplate(string $template): ActorInterface;
+
+    public function getPreferredTemplateTrees(): StringMapInterface;
+    public function setPreferredTemplateTrees(StringMapInterface $preferred_template_trees): ActorInterface;
+    public function hasPreferredTemplateTrees(): bool;
+
+    public function getAnnotationProcessors(): AnnotationProcessor\MapInterface;
+    public function setAnnotationProcessors(AnnotationProcessor\MapInterface $annotation_processors): ActorInterface;
+    public function hasAnnotationProcessors(): bool;
+}

--- a/src/V2/Api/FabricationFileInterface.php
+++ b/src/V2/Api/FabricationFileInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\Buphalo\V2\Api;
+
+use Neighborhoods\Buphalo\V2\StringMapInterface;
+
+interface FabricationFileInterface extends \JsonSerializable
+{
+    public const PROP_PREFERRED_TEMPLATE_TREES = 'preferred_template_trees';
+    public const PROP_ACTORS = 'actors';
+    public const PROP_RELATIVE_PATH = 'relative_path';
+    public const PROP_PRIMARY_ACTOR_NAME = 'primary_actor_name';
+
+    public function getPreferredTemplateTrees(): StringMapInterface;
+    public function setPreferredTemplateTrees(StringMapInterface $preferred_template_trees): FabricationFileInterface;
+    public function hasPreferredTemplateTrees(): bool;
+
+    public function getActors(): FabricationFile\Actor\MapInterface;
+    public function setActors(FabricationFile\Actor\MapInterface $actors): FabricationFileInterface;
+
+    public function getRelativePath(): string;
+    public function setRelativePath(string $relative_path): FabricationFileInterface;
+
+    public function getPrimaryActorName(): string;
+    public function setPrimaryActorName(string $primary_actor_name): FabricationFileInterface;
+}

--- a/src/V2/BooleanMap.php
+++ b/src/V2/BooleanMap.php
@@ -33,7 +33,7 @@ class BooleanMap extends ArrayIterator implements BooleanMapInterface
     }
 
     /** @param bool $boolean */
-    public function append($boolean)
+    public function append($boolean): void
     {
         $this->assertValidArrayItemType($boolean);
         parent::append($boolean);

--- a/src/V2/StringMap.php
+++ b/src/V2/StringMap.php
@@ -8,18 +8,18 @@ use LogicException;
 
 class StringMap extends ArrayIterator implements StringMapInterface
 {
-    /** @param string ...$Actors */
-    public function __construct(array $Actors = [], int $flags = 0)
+    /** @param string ...$strings */
+    public function __construct(array $strings = [], int $flags = 0)
     {
         if ($this->count() !== 0) {
             throw new LogicException('Map is not empty.');
         }
 
-        if (!empty($Actors)) {
-            $this->assertValidArrayType(...array_values($Actors));
+        if (!empty($strings)) {
+            $this->assertValidArrayType(...array_values($strings));
         }
 
-        parent::__construct($Actors, $flags);
+        parent::__construct($strings, $flags);
     }
 
     public function offsetGet($index): string


### PR DESCRIPTION
Changes manually copied from #77.

All `src/V2/Api` files were C&O with the equivalent of `s/V1/V2/g`