### PR TITLE
Revert "HOTFIX | allow 2.0.0 to replace 1.0.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,9 +33,6 @@
     "symfony/finder": "^4.4.30",
     "symfony/yaml": "^4.2"
   },
-  "replace": {
-    "neighborhoods/buphalo": "1.4.*"
-  },
   "autoload": {
     "psr-4": {
       "Neighborhoods\\Buphalo\\": [


### PR DESCRIPTION
This reverts commit 3895d6f79005cb5b1cfdc1198ff0ebe6f2f75429 (which was apparently merged to master without a PR because I forgot to check out a new branch and the branch protection rules wasn't set to apply to administrators).

Composer doesn't allow a package to replace itself. For testing purposes, I'll probably go with a 1.5.0-alpha release. Technically because the currently state of buphalo shouldn't break anything in the 1.0 API, this is still correct SemVer and theoretically we wouldn't need to move to 2.0 until we dropped or broke any 1.X contracts.  